### PR TITLE
add stdout flushing to print transcription in realtime

### DIFF
--- a/examples/nemo/streaming_asr.py
+++ b/examples/nemo/streaming_asr.py
@@ -73,6 +73,7 @@ if len(input_devices):
     try:
         while stream.is_active():
             time.sleep(0.1)
+            sys.stdout.flush()
     finally:        
         stream.stop_stream()
         stream.close()


### PR DESCRIPTION
this fixes the issue where we have to stop the stream before seeing the transcriptions by ASR. working as tested on Ubuntu 16.04